### PR TITLE
Build all tests in `tests/Makefile`

### DIFF
--- a/.github/workflows/ada.yml
+++ b/.github/workflows/ada.yml
@@ -25,9 +25,4 @@ jobs:
 
     - name: Build tests
       run: >
-        cd tests &&
-        for dir in clock example music opengl renderwindow thread window; do
-          cd $dir &&
-          gprbuild -j0 -p main.gpr &&
-          cd - ;
-        done
+        make -k -C tests


### PR DESCRIPTION
In this way, new tests have to be added only in Makefile and not here.